### PR TITLE
Compile `tests/java` to a separate `test-classes` directory

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -137,6 +137,11 @@
         <property name="extlibs.dir" value="${jython.base.dir}/extlibs" />
         <property name="output.dir" value="${work.dir}/build" />
         <property name="compile.dir" value="${output.dir}/classes" />
+        <!-- Test fixtures from ${test.source.dir} are compiled here, NOT into
+             ${compile.dir}, so that they don't leak into ${jython.dev.jar}.
+             Leaking test classes (especially ProxyDeserialization at the default
+             package) breaks downstream OSGi bundle wrapping; see wala/ML#557. -->
+        <property name="test.compile.dir" value="${output.dir}/test-classes" />
         <property name="exposed.dir" value="${output.dir}/exposed" />
         <property name="gensrc.dir" value="${output.dir}/gensrc" />
         <property name="dist.dir" value="${work.dir}/dist" />
@@ -209,6 +214,7 @@
           -->
           <pathelement path="${exposed.dir}" />
           <pathelement path="${compile.dir}" />
+          <pathelement path="${test.compile.dir}" />
           <pathelement path="${cpptasks.jar.dir}" />
         </path>
         <property name="jython.dev.jar" value="jython-dev.jar" />
@@ -339,6 +345,7 @@
       <!-- create output directories -->
       <target name ="prepare-output" depends="init,needed-check,clean-if-antlr-needed">
         <mkdir dir="${compile.dir}" />
+        <mkdir dir="${test.compile.dir}" />
         <mkdir dir="${gensrc.dir}/org/python/antlr" />
         <mkdir dir="${exposed.dir}" />
         <mkdir dir="${dist.dir}" />
@@ -515,9 +522,10 @@
         <compilerarg line="${javac.Xlint}"/>
       </javac>
 
-      <!-- java files used by tests -->
+      <!-- java files used by tests; kept out of ${compile.dir} so that
+           ${jython.dev.jar} contains production classes only (wala/ML#557). -->
       <javac srcdir="${test.source.dir}"
-        destdir="${compile.dir}"
+        destdir="${test.compile.dir}"
         target="${jdk.target.version}"
         source="${jdk.source.version}"
         debug="${debug}"


### PR DESCRIPTION
## Summary

`build.xml`'s `compile` target javac'd `tests/java/` into the same `${compile.dir}` that the `jar` target packages into `${jython.dev.jar}`. Net effect: every test fixture in `tests/java/` shipped inside the production JAR — including `ProxyDeserialization.class`, a default-package class that breaks OSGi bundle wrapping (Tycho 5+'s bnd auto-wrap rejects default-package classes with `The default package '.' is not permitted by the Import-Package syntax`).

This change adds a `${test.compile.dir}` (sibling of `${compile.dir}`), redirects the `tests/java` javac there, and threads the new directory into `test.classpath` so the existing test runners still find compiled fixtures.

## Verification

Local `ant` build is green; `dist/jython-dev.jar` now contains zero default-package classes:

```
$ jar tf dist/jython-dev.jar | grep -E '^[A-Z][^/]*\.class$'
(no output)
```

`build/test-classes/` correctly contains the previously-leaked classes (`ProxyDeserialization.class`, `javatests/`, `org/`) where the test runners can still load them via `test.classpath`.

## Downstream

Resolves wala/ML#557 once Ariadne consumes a build of `jython3` that includes this commit. The Ariadne side will (a) bump its submodule pointer, (b) bump the local-install version coordinate to force a cache-bust, and (c) drop its own redundant `<exclude>ProxyDeserialization.class</exclude>` shade filter.