### PR TITLE
Restore the embedded Jython interpreter init

### DIFF
--- a/src/org/python/core/PySystemState.java
+++ b/src/org/python/core/PySystemState.java
@@ -1149,8 +1149,8 @@ public class PySystemState extends PyObject implements AutoCloseable, Closeable,
         SysModule.setObject("_jy_console", Py.java2py(Py.getConsole()));
 
         try {
-            InputStream _frozen_importlib_input =  new FileInputStream(new File("src/resources/frozen_importlib/_frozen_importlib.class"));
-            InputStream _frozen_importlib_external_input =  new FileInputStream(new File("src/resources/frozen_importlib/_frozen_importlib_external.class"));
+            InputStream _frozen_importlib_input = openFrozenImportlib("_frozen_importlib.class");
+            InputStream _frozen_importlib_external_input = openFrozenImportlib("_frozen_importlib_external.class");
             PyObject _frozen_importlib = imp.loadFromCompiled("_frozen_importlib", _frozen_importlib_input, "_bootstrap.py", "_frozen_importlib.class");
             imp.loadFromCompiled("_frozen_importlib_external", _frozen_importlib_external_input, "_bootstrap_external.py", "_frozen_importlib_external.class");
             Py.defaultSystemState.importlib = _frozen_importlib;
@@ -1162,6 +1162,29 @@ public class PySystemState extends PyObject implements AutoCloseable, Closeable,
         Py.defaultSystemState.initstdio();
         Py.defaultSystemState.initEncoding();
         return Py.defaultSystemState;
+    }
+
+    /**
+     * Opens a frozen importlib bootstrap resource independent of the current working directory.
+     * Tries the classpath first (when the resources are packaged on it), then resolves under {@code
+     * python.home} (the prefix that embedding clients and tests point at Jython's resources), and
+     * only then falls back to the historical working-directory-relative path. Loading from a bare
+     * relative path failed whenever Jython was initialized from a directory other than the source
+     * tree root (e.g., a Maven module or an OSGi bundle), leaving {@code sys.importlib} null.
+     */
+    private static InputStream openFrozenImportlib(String name) throws FileNotFoundException {
+        InputStream onClasspath = PySystemState.class.getResourceAsStream("/frozen_importlib/" + name);
+        if (onClasspath != null) {
+            return onClasspath;
+        }
+        if (prefix != null && prefix.toString().length() > 0) {
+            File underHome =
+                    new File(new File(prefix.toString(), "src/resources/frozen_importlib"), name);
+            if (underHome.isFile()) {
+                return new FileInputStream(underHome);
+            }
+        }
+        return new FileInputStream(new File("src/resources/frozen_importlib/" + name));
     }
 
     private static PyTuple getVersionInfo() {

--- a/src/org/python/util/PythonInterpreter.java
+++ b/src/org/python/util/PythonInterpreter.java
@@ -6,6 +6,7 @@ import org.python.core.CompilerFlags;
 import org.python.core.ParserFacade;
 import org.python.core.Py;
 import org.python.core.PyBytes;
+import org.python.core.PyUnicode;
 import org.python.core.PyCode;
 import org.python.core.PyException;
 import org.python.core.PyFile;
@@ -246,7 +247,10 @@ public class PythonInterpreter implements AutoCloseable, Closeable {
      */
     public PyObject eval(String s) {
         setSystemState();
-        return __builtin__.eval(new PyBytes(s), getLocals());
+        // Python 3's eval() requires a str (or code object); a bytes argument raises
+        // "eval: argument 1 must be string or code object". The source must therefore be a
+        // PyUnicode, not a PyBytes (the latter is the post-PEP-393 bytes type).
+        return __builtin__.eval(new PyUnicode(s), getLocals());
     }
 
     /**


### PR DESCRIPTION
**Draft — preservation/reference branch, not ready to merge.** Tracks wala/ML#580.

Two fixes that get the embedded Jython-3 interpreter initializing again (it currently fails, so all interpreter-based evaluation — constant folding, shape-argument evaluation via `interpretAsInt`/`evalAsInteger` — degrades to `null`):

- **Load `frozen_importlib` independent of the working directory** — the bootstrap resources were read via a cwd-relative `FileInputStream`, which fails outside the Jython working dir. Loads via classpath → `python.home`(prefix) → cwd instead. Also bundles the `jnr`/`jffi` FFI deps (fat jar) so init doesn't `NoClassDefFoundError`.
- **Evaluate a string expression as Python `str`, not `bytes`** — `PythonInterpreter.eval(String)` wrapped the source in `PyBytes`; `__builtin__.eval` needs a `str`/code object (`PyUnicode`). Regression from the 2016 PEP-393 `PyString`→`PyBytes` rename (761f17ff3).

## Why this is a draft, not a merge

Enabling the interpreter installs `importlib`, which changes how `typing.NamedTuple` resolves and regresses the downstream `NamedTuple`-field propagation that just shipped in wala/ML (the constructor field-population gates on `NamedTuple` being an unresolved/"missing" type). That interaction must be resolved before the interpreter can be turned back on — see wala/ML#580. This branch preserves the init fixes so they aren't lost while that blocker is worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)